### PR TITLE
Fix stray ) in <menclose> default notation (#5)

### DIFF
--- a/mathml2tex/xsl_yarosh/glayout.xsl
+++ b/mathml2tex/xsl_yarosh/glayout.xsl
@@ -162,8 +162,13 @@
 			<xsl:apply-templates/>
 			<xsl:text>}</xsl:text>
 		</xsl:when>
-		<xsl:otherwise>
+		<xsl:when test="@notation = 'longdiv'">
 			<xsl:text>\overline{)</xsl:text>
+			<xsl:apply-templates/>
+			<xsl:text>}</xsl:text>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:text>\overline{</xsl:text>
 			<xsl:apply-templates/>
 			<xsl:text>}</xsl:text>
 		</xsl:otherwise>

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -136,6 +136,37 @@ class TestSanitizeStatement:
         assert sanitize_statement("") == ""
 
 
+class TestMenclose:
+    def test_top_produces_plain_overline(self):
+        mathml = (
+            b'<math xmlns="http://www.w3.org/1998/Math/MathML">'
+            b'<menclose notation="top"><mi>A</mi><mi>B</mi></menclose>'
+            b'<mo>=</mo><mn>2</mn></math>'
+        )
+        assert convert_mathml2tex(mathml) == r"\overline{AB}=2"
+
+    def test_default_notation_produces_plain_overline(self):
+        mathml = (
+            b'<math xmlns="http://www.w3.org/1998/Math/MathML">'
+            b"<menclose><mi>x</mi></menclose></math>"
+        )
+        assert convert_mathml2tex(mathml) == r"\overline{x}"
+
+    def test_longdiv_keeps_paren(self):
+        mathml = (
+            b'<math xmlns="http://www.w3.org/1998/Math/MathML">'
+            b'<menclose notation="longdiv"><mn>123</mn></menclose></math>'
+        )
+        assert r"\overline{)" in convert_mathml2tex(mathml)
+
+    def test_radical_still_works(self):
+        mathml = (
+            b'<math xmlns="http://www.w3.org/1998/Math/MathML">'
+            b'<menclose notation="radical"><mi>x</mi></menclose></math>'
+        )
+        assert convert_mathml2tex(mathml) == r"\sqrt{x}"
+
+
 class TestSanitizeHtmlHelper:
     def test_allows_p(self):
         assert _sanitize_html("<p>x</p>") == "<p>x</p>"


### PR DESCRIPTION
Closes #5.

\`<menclose notation=\"top\">\` previously produced \`\\overline{)AB}\` — the stray \`)\` inside the brace. Root cause: every notation except \`actuarial\` / \`radical\` fell through to an \`<xsl:otherwise>\` block that hard-coded \`\\overline{)\`. The \`)\` actually belongs to the \`longdiv\` rendering ('long-division bracket') and had been glued onto the catch-all by accident.

This PR:
- Adds a \`longdiv\` branch that keeps the \`\\overline{)...\`}\` output (so any caller relying on long-division notation is unaffected).
- Strips the \`)\` from the catch-all so \`top\`, \`bottom\`, \`box\`, \`circle\`, \`left\`, \`right\`, etc. produce a clean \`\\overline{...}\`.

Regression tests cover \`notation=\"top\"\`, the default (no notation), \`longdiv\`, and a sanity check on \`radical\`. Coverage stays at 100%.

## Test plan
- [x] \`pytest\` → 33 passing, 100% line + branch coverage.
- [x] Original reporter's input (\`<menclose notation=\"top\">…\`) now yields \`\\overline{AB}=2\`.
- [x] \`longdiv\` path still emits the \`\\overline{)\` long-division syntax.