### PR TITLE
README: mark maintenance mode and point to alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # mathml2tex
 
-Convert MathML to LaTeX. A thin Python wrapper around Vasil Yaroshevich's
-XSLT 1.0 stylesheet (`xsltml`, now bundled under `mathml2tex/xsl_yarosh/`),
-with inline-HTML sanitization on top for mixed content such as quiz
-statements or textbook passages.
+A thin Python wrapper around Vasil Yaroshevich's XSLT 1.0 stylesheet
+(`xsltml`, bundled under `mathml2tex/xsl_yarosh/`) that converts
+**MathML 2.0** to **LaTeX**, with optional inline-HTML sanitization for
+mixed content such as quiz statements or textbook passages.
 
 See [`HISTORY.md`](HISTORY.md) for the provenance of the bundled stylesheets.
+
+## Status: maintenance mode
+
+The underlying XSLT stylesheet (`xsltml`) was last released in **2007** and
+only targets **MathML 2.0**. It does not support MathML 3.0 elements
+(`mlongdiv`, `mstack`, `maction`, `mlabeledtr`, `mscarries`) and has no
+real Content MathML coverage for modern inputs.
+
+This package still works well for its original use case — converting
+Presentation MathML 2.0 fragments, with HTML sanitization on top — and
+has been hardened for security (XXE/SSRF-safe parsing, nh3 allowlist,
+100% test coverage). **If that's your use case, use it.**
+
+If you need any of the following, pick an actively-maintained alternative
+from the list below:
+- MathML 3 / MathML 4 elements
+- Robust Content MathML support
+- A larger community / more momentum behind the tool
+
+## Alternatives
+
+| Tool | Language | MathML version | Notes |
+| --- | --- | --- | --- |
+| [`mathml-to-latex`](https://pypi.org/project/mathml-to-latex/) | Python (pure) | 2 + partial 3 | Drop-in PyPI alternative, actively maintained. **Recommended for most new projects.** |
+| [Pandoc](https://pandoc.org/) (`texmath`) | Haskell | 2 + 3 | General-purpose document converter; MathML→LaTeX is one of many paths. |
+| [`transpect/mml2tex`](https://github.com/transpect/mml2tex) | XSLT 2.0 | 2 + 3 | Actively-maintained descendant of `xsltml`; requires a Saxon (Java) runtime. Includes a Content→Presentation normalizer. |
 
 ## Install
 
@@ -15,7 +41,7 @@ pip install mathml2tex
 
 ## Usage
 
-### As a library
+### Library
 
 ```python
 from mathml2tex import convert_mathml2tex, sanitize_statement
@@ -33,35 +59,35 @@ sanitize_statement(html)
 # -> '<p>The ratio is \\( \\frac{a}{b} \\).</p>'
 ```
 
-`convert_mathml2tex` accepts either `str` or `bytes`. On invalid input it
-raises `mathml2tex.converter.Mathml2TexError`.
+`convert_mathml2tex` accepts `str` or `bytes`. Invalid MathML, missing
+namespace, or transform failures raise `mathml2tex.converter.Mathml2TexError`.
 
-`sanitize_statement` takes HTML containing zero or more `<math>` blocks,
-replaces each block with its LaTeX equivalent wrapped in `\( ... \)`
-delimiters, and runs the result through [nh3](https://pypi.org/project/nh3/)
-with an allowlist suited to educational content. Pass `strict=False` to
-log-and-skip unconvertible blocks instead of raising.
+`sanitize_statement` replaces each inline `<math>` block with its LaTeX
+equivalent wrapped in `\( ... \)`, then allowlist-sanitizes the result
+with [nh3](https://pypi.org/project/nh3/). Pass `strict=False` to skip
+and log unconvertible blocks instead of raising.
 
-### As a CLI
+### CLI
 
 ```sh
 mathml2tex equation.xml                 # standalone MathML → LaTeX
-cat page.html | mathml2tex --html       # HTML with inline <math> → sanitized HTML
+cat page.html | mathml2tex --html       # HTML with inline <math>
 echo "$MATHML" | mathml2tex             # from stdin
 ```
 
 ## Security
 
-The XML parser is configured to reject external entities and network
-fetches; the XSLT transform denies all I/O access. MathML from untrusted
-sources is safe to hand directly to `convert_mathml2tex`.
+The XML parser rejects external entities and network fetches; the XSLT
+transform denies all I/O (`XSLTAccessControl.DENY_ALL`). MathML from
+untrusted sources is safe to hand directly to `convert_mathml2tex`.
 
 ## Compatibility
 
 - Python 3.8+
-- lxml 4.9+ (4.x or 5.x or 6.x)
+- lxml 4.9+ (supports lxml 4.x, 5.x, 6.x)
 
 ## License
 
-MIT. See `LICENSE`. The bundled `xsl_yarosh/` stylesheets carry their own
-permissive license from Vasil Yaroshevich, preserved in each file header.
+MIT. See `LICENSE`. The bundled `xsl_yarosh/` stylesheets carry their
+own permissive license from Vasil Yaroshevich, preserved in each file
+header.


### PR DESCRIPTION
Updates the README to:

- Add a **Status: maintenance mode** section at the top, explaining the xsltml freeze at MathML 2.0.
- Add an **Alternatives** table recommending \`mathml-to-latex\` (PyPI), Pandoc, and transpect/\`mml2tex\` depending on the reader's needs.
- Keep the existing install / usage / CLI / security / compat sections for users who still want the original Presentation-MathML-2 + HTML-sanitization behavior this package provides.

No code changes.

## Test plan
- [x] Markdown renders cleanly on GitHub.